### PR TITLE
fix(rightsizing): restrict placement to OpenShift clusters only

### DIFF
--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/placement.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/placement.go
@@ -16,11 +16,24 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetDefaultRSPlacement creates a default placement configuration for right-sizing
+// GetDefaultRSPlacement creates a default placement configuration for right-sizing.
+// It restricts placement to OpenShift clusters only (vendor=OpenShift) because
+// right-sizing policies deploy PrometheusRules to the openshift-monitoring namespace,
+// which does not exist on non-OpenShift clusters (e.g. AKS).
 func GetDefaultRSPlacement() clusterv1beta1.Placement {
 	return clusterv1beta1.Placement{
 		Spec: clusterv1beta1.PlacementSpec{
-			Predicates: []clusterv1beta1.ClusterPredicate{},
+			Predicates: []clusterv1beta1.ClusterPredicate{
+				{
+					RequiredClusterSelector: clusterv1beta1.ClusterSelector{
+						LabelSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"vendor": "OpenShift",
+							},
+						},
+					},
+				},
+			},
 			Tolerations: []clusterv1beta1.Toleration{
 				{
 					Key:      "cluster.open-cluster-management.io/unreachable",

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/placement_test.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/placement_test.go
@@ -19,7 +19,13 @@ import (
 func TestGetDefaultRSPlacement(t *testing.T) {
 	placement := GetDefaultRSPlacement()
 
-	assert.Empty(t, placement.Spec.Predicates)
+	// Verify vendor=OpenShift predicate restricts placement to OpenShift clusters only
+	assert.Len(t, placement.Spec.Predicates, 1, "should have exactly one predicate for vendor=OpenShift")
+	predicate := placement.Spec.Predicates[0]
+	assert.Equal(t, map[string]string{"vendor": "OpenShift"},
+		predicate.RequiredClusterSelector.LabelSelector.MatchLabels,
+		"predicate should require vendor=OpenShift label")
+
 	assert.Len(t, placement.Spec.Tolerations, 2)
 
 	// Check tolerations


### PR DESCRIPTION
<!-- issue-fix-agent:jira=OBSINTA-1296 session=manual -->

## Summary
Restrict right-sizing policy placement to OpenShift clusters only by adding a `vendor=OpenShift` label selector predicate to the default placement configuration.

## Root Cause
`GetDefaultRSPlacement()` in `rs-utility/placement.go` created a Placement with empty `Predicates`, causing right-sizing policies (`rs-prom-rules-policy` and `rs-virt-prom-rules-policy`) to be deployed to ALL managed clusters including non-OpenShift distributions (e.g., AKS). These policies enforce PrometheusRules in the `openshift-monitoring` namespace, which does not exist on non-OpenShift clusters, causing policy failures.

## Changes
- `rs-utility/placement.go`: Added `vendor=OpenShift` `RequiredClusterSelector` predicate to `GetDefaultRSPlacement()` with explanatory comment
- `rs-utility/placement_test.go`: Updated `TestGetDefaultRSPlacement` to verify vendor predicate exists and matches `vendor=OpenShift`

## Testing
- [x] All 97 existing tests pass across analytics/rightsizing packages
- [x] Regression test updated (TestGetDefaultRSPlacement now validates vendor predicate)
- [x] Build and vet pass

## Jira
[OBSINTA-1296](https://stage-redhat.atlassian.net/browse/OBSINTA-1296)

---
Assisted-by: Claude Code / Opus 4.6 (Anthropic)