### PR TITLE
fix(rightsizing): restrict placement to OpenShift clusters only

### DIFF
--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/placement.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/placement.go
@@ -16,11 +16,24 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetDefaultRSPlacement creates a default placement configuration for right-sizing
+// GetDefaultRSPlacement creates a default placement configuration for right-sizing.
+// The placement restricts deployment to OpenShift clusters only (vendor=OpenShift)
+// because right-sizing policies enforce PrometheusRules in the openshift-monitoring
+// namespace, which does not exist on non-OpenShift clusters.
 func GetDefaultRSPlacement() clusterv1beta1.Placement {
 	return clusterv1beta1.Placement{
 		Spec: clusterv1beta1.PlacementSpec{
-			Predicates: []clusterv1beta1.ClusterPredicate{},
+			Predicates: []clusterv1beta1.ClusterPredicate{
+				{
+					RequiredClusterSelector: clusterv1beta1.ClusterSelector{
+						LabelSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"vendor": "OpenShift",
+							},
+						},
+					},
+				},
+			},
 			Tolerations: []clusterv1beta1.Toleration{
 				{
 					Key:      "cluster.open-cluster-management.io/unreachable",

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/placement_test.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/placement_test.go
@@ -19,7 +19,13 @@ import (
 func TestGetDefaultRSPlacement(t *testing.T) {
 	placement := GetDefaultRSPlacement()
 
-	assert.Empty(t, placement.Spec.Predicates)
+	// Check predicates restrict to OpenShift clusters only
+	assert.Len(t, placement.Spec.Predicates, 1, "should have exactly one predicate for vendor=OpenShift")
+	predicate := placement.Spec.Predicates[0]
+	assert.Equal(t, map[string]string{"vendor": "OpenShift"},
+		predicate.RequiredClusterSelector.LabelSelector.MatchLabels,
+		"predicate should select vendor=OpenShift clusters only")
+
 	assert.Len(t, placement.Spec.Tolerations, 2)
 
 	// Check tolerations


### PR DESCRIPTION
<!-- issue-fix-agent:jira=OBSINTA-1297 session=manual -->

## Summary
Restrict right-sizing policy placement to OpenShift clusters only by adding a `vendor=OpenShift` cluster predicate to the default placement configuration.

## Root Cause
`GetDefaultRSPlacement()` in `rs-utility/placement.go` created a Placement with empty predicates (`Predicates: []clusterv1beta1.ClusterPredicate{}`), which matched ALL managed clusters including non-OpenShift distributions (e.g., AKS). Right-sizing policies enforce PrometheusRules in the `openshift-monitoring` namespace, which does not exist on non-OpenShift clusters.

## Changes
- `rs-utility/placement.go`: Added `ClusterPredicate` with `RequiredClusterSelector` using `LabelSelector{MatchLabels: {"vendor": "OpenShift"}}` to restrict placement to OpenShift clusters only
- `rs-utility/placement_test.go`: Updated `TestGetDefaultRSPlacement` to verify the `vendor=OpenShift` predicate is present (regression test)

## Testing
- [x] Existing tests pass (93 tests across 4 packages)
- [x] Regression test added (`TestGetDefaultRSPlacement` updated)
- [x] Build and vet pass

## Jira
[OBSINTA-1297](https://stage-redhat.atlassian.net/browse/OBSINTA-1297)

---
Assisted-by: Claude Code / Opus 4.6 (Anthropic)